### PR TITLE
WIP: Bump rustler version to support OTP 20

### DIFF
--- a/native/gauc/Cargo.toml
+++ b/native/gauc/Cargo.toml
@@ -13,6 +13,7 @@ byteorder = "1.1"
 gauc = "0.6.1"
 # gauc = { version = "0.6.1", path = "../../../gauc" }
 lazy_static = "0.2"
-rustler = "0.15.1"
+# bring back version after rustler > 0.15.1 is release
+rustler = { git = "https://github.com/hansihe/rustler" }
 rustler_codegen = "0.15.1"
 uuid = { version = "0.5", features = ["v4"] }


### PR DESCRIPTION
Rustler's dependency `erlang_nif-sys` has to be in version `>=0.6.3` to support OTP20, which already is in `master` but not yet released – I will update this PR as soon as this happens.